### PR TITLE
Recheck links after "more" button press

### DIFF
--- a/greasemonkey_hook_googlesearch.user.js
+++ b/greasemonkey_hook_googlesearch.user.js
@@ -6,7 +6,7 @@
 // @run-at document-end
 // @grant none
 // @downloadURL https://github.com/bentasker/RemoveAMP/raw/master/greasemonkey_hook_googlesearch.user.js
-// @version 1.4.1
+// @version 1.4.2
 //
 //
 // See https://projects.bentasker.co.uk/jira_projects/browse/MISC-29.html#comment2512640
@@ -15,27 +15,46 @@
 // ==/UserScript==
 
 
-var da;
-var bads = ['data-amp','data-amp-cur','data-amp-title','data-amp-vgi','ping'];
-var eles = document.getElementsByClassName('amp_r');
-for (var i=0; i<eles.length; i++){
-    if (eles[i].tagName.toLowerCase() != 'a'){
-        continue;
-    }
+var AMPCheck = debounce(function() {
+	var da;
+	var bads = ['data-amp','data-amp-cur','data-amp-title','data-amp-vgi','ping'];
+	var eles = document.getElementsByClassName('amp_r');
+	for (var i=0; i<eles.length; i++){
+		if (eles[i].tagName.toLowerCase() != 'a'){
+			continue;
+		}
+		da = eles[i].getAttribute('data-amp-cur');
+		if (! da){
+			continue;
+		}
+		if (!da.includes('?')){
+			da += '?';
+		}
+		eles[i].href = da;
 
-    da = eles[i].getAttribute('data-amp-cur');
-    if (! da){
-        continue;
-    }
-    
-    if (!da.includes('?')){
-        da += '?';
-    }
-    
-    eles[i].href = da;
-    
-    for (n=0; n<bads.length; n++){
-        eles[i].removeAttribute(bads[n]);
-    }
-    
-}
+		for (n=0; n<bads.length; n++){
+			eles[i].removeAttribute(bads[n]);
+		}
+	}
+}, 500);
+
+/* Taken from https://davidwalsh.name/javascript-debounce-function */
+function debounce(func, wait, immediate) {
+	var timeout;
+	return function() {
+		var context = this, args = arguments;
+		var later = function() {
+			timeout = null;
+			if (!immediate) func.apply(context, args);
+		};
+		var callNow = immediate && !timeout;
+		clearTimeout(timeout);
+		timeout = setTimeout(later, wait);
+		if (callNow) func.apply(context, args);
+	};
+};
+
+window.addEventListener ("load", function(){
+	AMPCheck();
+	document.addEventListener("DOMNodeInserted", AMPCheck, false);
+}, false);


### PR DESCRIPTION
Previously, if the user clicked the "more" button to load additional search results, the new results would still be AMP'd. To fix this, we need to recheck all links after the additional results have been added to the page.

Clicking "more" results in many fires of the `DOMNodeInserted` event. This commit re-runs the AMP check after such an event, with a 500ms debounce.