### PR TITLE
Start script earlier

### DIFF
--- a/greasemonkey_hook.user.js
+++ b/greasemonkey_hook.user.js
@@ -3,10 +3,10 @@
 // @namespace      http
 // @description    Hooks in the AMP removal javascript to attempt to direct to a proper page
 // @include        *://*/*
-// @run-at document-end
+// @run-at document-start
 // @grant none
 // @downloadURL https://github.com/bentasker/RemoveAMP/raw/master/greasemonkey_hook.user.js
-// @version 1.6
+// @version 1.6.1
 //
 // @require https://static1.bentasker.co.uk/adblock/anti-amp/v1.6.js#sha384=gHVG5HeMAn/WWFJ6VBkahDMFvDXJbkiroOJuVtz2l/gvvnhabGCRjbJphz5qMASw
 //
@@ -14,7 +14,7 @@
 // Author: B Tasker
 // ==/UserScript==
 
-window.addEventListener ("load", triggerAMPCheck, false);
+window.addEventListener ("DOMContentLoaded", triggerAMPCheck, false);
 
 function triggerAMPCheck () {
     fuckOffAMP();


### PR DESCRIPTION
This way there's not a 5-10 second delay (as tested on mobile) between page load and redirect. Tested on a handful of news sites and it's working okay
